### PR TITLE
feat: Escape quotes on key.

### DIFF
--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -174,7 +174,7 @@ func getEsActionJSON(docID []byte, action document.EsAction, indexName string, r
 	}
 	meta = append(meta, helper.Byte(indexName)...)
 	meta = append(meta, idPrefix...)
-	meta = append(meta, docID...)
+	meta = append(meta, helper.EscapePredefinedBytes(docID)...)
 	if routing != nil {
 		meta = append(meta, routingPrefix...)
 		meta = append(meta, helper.Byte(*routing)...)

--- a/helper/escape.go
+++ b/helper/escape.go
@@ -1,0 +1,21 @@
+package helper
+
+var (
+	EscapeBytes = []byte{
+		34, // quote
+	}
+	BackSlash byte = 92
+)
+
+func EscapePredefinedBytes(docID []byte) []byte {
+	newByteArr := make([]byte, 0, len(docID))
+	for _, byt := range docID {
+		for _, escapeByte := range EscapeBytes {
+			if escapeByte == byt {
+				newByteArr = append(newByteArr, BackSlash)
+			}
+		}
+		newByteArr = append(newByteArr, byt)
+	}
+	return newByteArr
+}

--- a/helper/escape_test.go
+++ b/helper/escape_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestEscapeQuote(t *testing.T) {
 	input := "12345-999\""
-	byteArr := Byte(input)
+	byteArr := []byte(input)
 	result := EscapePredefinedBytes(byteArr)
 	if len(result) == 10 || result[len(result)-1] != 34 {
 		t.Error("Expected backslash byte")
@@ -15,7 +15,7 @@ func TestEscapeQuote(t *testing.T) {
 
 func TestDoNotEscapeQuote(t *testing.T) {
 	input := "12345-999"
-	byteArr := Byte(input)
+	byteArr := []byte(input)
 
 	result := EscapePredefinedBytes(byteArr)
 	if len(result) != 9 {

--- a/helper/escape_test.go
+++ b/helper/escape_test.go
@@ -1,0 +1,29 @@
+package helper
+
+import (
+	"testing"
+)
+
+func TestEscapeQuote(t *testing.T) {
+	input := "12345-999\""
+	byteArr := Byte(input)
+	result := EscapePredefinedBytes(byteArr)
+	if len(result) == 10 || result[len(result)-1] != 34 {
+		t.Error("Expected backslash byte")
+	}
+}
+
+func TestDoNotEscapeQuote(t *testing.T) {
+	input := "12345-999"
+	byteArr := Byte(input)
+
+	result := EscapePredefinedBytes(byteArr)
+	if len(result) != 9 {
+		t.Error("Not expected any change related with length")
+	}
+	for _, b := range result {
+		if b == 34 {
+			t.Error("Not expected any backslash")
+		}
+	}
+}


### PR DESCRIPTION
* I've added a method that adds backslash if any byte is in the predefined escape list.
* Added some test cases.

I thought no need to call this method for source, couchbase not allowed to use quotes without escaped.