### PR TITLE
feat: handle bulk request error with sink response handler

### DIFF
--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -388,12 +388,12 @@ func (b *Bulk) getIndexName(collectionName, actionIndexName string) string {
 }
 
 func fillErrorDataWithBulkRequestError(batchActions []*document.ESActionDocument, err error) map[string]string {
-	result := make(map[string]string, len(batchActions))
+	errorData := make(map[string]string, len(batchActions))
 	for _, action := range batchActions {
 		key := getActionKey(*action)
-		result[key] = err.Error()
+		errorData[key] = err.Error()
 	}
-	return result
+	return errorData
 }
 
 func (b *Bulk) executeSinkResponseHandler(batchActions []*document.ESActionDocument, errorData map[string]string) {

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -1,0 +1,114 @@
+package bulk
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch"
+	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch/document"
+	"reflect"
+	"testing"
+)
+
+func Test_getActions(t *testing.T) {
+	// Given
+	givenBatchItems := []BatchItem{
+		{Action: &document.ESActionDocument{ID: []byte("1")}},
+		{Action: &document.ESActionDocument{ID: []byte("2")}},
+	}
+
+	expected := []*document.ESActionDocument{
+		{ID: []byte("1")},
+		{ID: []byte("2")},
+	}
+
+	// When
+	result := getActions(givenBatchItems)
+
+	// Then
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatal("Must be equal")
+	}
+}
+
+func TestBulk_executeSinkResponseHandler(t *testing.T) {
+	t.Run("Should_Ignore_When_Not_Sink_Response_Handler_Specified", func(t *testing.T) {
+		// Given
+		sut := Bulk{}
+
+		// When
+		sut.executeSinkResponseHandler(nil, nil)
+
+		// Then
+	})
+	t.Run("Should_Handle_Success_And_Failure_Messages", func(t *testing.T) {
+		// Given
+		handler := mockSinkResponseHandler{}
+
+		sut := Bulk{
+			sinkResponseHandler: &handler,
+			metric: &Metric{
+				IndexingSuccessActionCounter: map[string]int64{},
+				IndexingErrorActionCounter:   map[string]int64{},
+			},
+		}
+
+		batchActions := []*document.ESActionDocument{
+			{IndexName: "someIndex", ID: []byte("1"), Type: document.Index},
+			{IndexName: "someIndex", ID: []byte("2"), Type: document.Index},
+		}
+
+		errorData := map[string]string{
+			"2:someIndex": "a error occurred",
+		}
+
+		// When
+		sut.executeSinkResponseHandler(batchActions, errorData)
+
+		// Then
+		if handler.successResult != "1:someIndex" {
+			t.Fatalf("Success Result must be `someIndex:1` but has %s", handler.successResult)
+		}
+		if sut.metric.IndexingSuccessActionCounter["someIndex"] != 1 {
+			t.Fatalf("Indexing success action counter must equal to 1 but has %d", sut.metric.IndexingSuccessActionCounter["someIndex"])
+		}
+		if handler.errorResult != "2:someIndex Error=a error occurred" {
+			t.Fatalf("Success Result must be `2:someIndex Error=a error occurred` but has %s", handler.errorResult)
+		}
+		if sut.metric.IndexingErrorActionCounter["someIndex"] != 1 {
+			t.Fatalf("Indexing error action counter must equal to 1 but has %d", sut.metric.IndexingErrorActionCounter["someIndex"])
+		}
+	})
+}
+
+func Test_fillErrorDataWithBulkRequestError(t *testing.T) {
+	// Given
+	batchActions := []*document.ESActionDocument{
+		{IndexName: "someIndex", ID: []byte("1"), Type: document.Index},
+		{IndexName: "someIndex", ID: []byte("2"), Type: document.Index},
+	}
+
+	// When
+	result := fillErrorDataWithBulkRequestError(batchActions, errors.New("bulk request error, 400"))
+
+	// Then
+	if result["1:someIndex"] != "bulk request error, 400" {
+		t.Fatalf("result' key `1:someIndex` must equal to `bulk request error, 400` but has %s", result["1:someIndex"])
+	}
+	if result["2:someIndex"] != "bulk request error, 400" {
+		t.Fatalf("result' key `2:someIndex` must equal to `bulk request error, 400` but has %s", result["2:someIndex"])
+	}
+}
+
+type mockSinkResponseHandler struct {
+	successResult string
+	errorResult   string
+}
+
+func (m *mockSinkResponseHandler) OnSuccess(ctx *elasticsearch.SinkResponseHandlerContext) {
+	m.successResult = fmt.Sprintf("%s:%s", ctx.Action.ID, ctx.Action.IndexName)
+}
+func (m *mockSinkResponseHandler) OnError(ctx *elasticsearch.SinkResponseHandlerContext) {
+	m.errorResult = fmt.Sprintf("%s:%s Error=%s", ctx.Action.ID, ctx.Action.IndexName, ctx.Err.Error())
+}
+
+func (m *mockSinkResponseHandler) OnInit(ctx *elasticsearch.SinkResponseHandlerInitContext) {}

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -3,10 +3,11 @@ package bulk
 import (
 	"errors"
 	"fmt"
-	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch"
-	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch/document"
 	"reflect"
 	"testing"
+
+	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch"
+	"github.com/Trendyol/go-dcp-elasticsearch/elasticsearch/document"
 )
 
 func Test_getActions(t *testing.T) {
@@ -107,6 +108,7 @@ type mockSinkResponseHandler struct {
 func (m *mockSinkResponseHandler) OnSuccess(ctx *elasticsearch.SinkResponseHandlerContext) {
 	m.successResult = fmt.Sprintf("%s:%s", ctx.Action.ID, ctx.Action.IndexName)
 }
+
 func (m *mockSinkResponseHandler) OnError(ctx *elasticsearch.SinkResponseHandlerContext) {
 	m.errorResult = fmt.Sprintf("%s:%s Error=%s", ctx.Action.ID, ctx.Action.IndexName, ctx.Err.Error())
 }


### PR DESCRIPTION
Problem:
When our client has bulk request errors like 

```
[400 Bad Request] {"error":{"root_cause":[{"type":"json_parse_exception","reason":"Illegal unquoted character ((CTRL-CHAR, code 0)): has to be escaped using backslash to be included in string value\n 
at [Source: (ByteArrayInputStream); line: 1, column: 45]"}],"type":"json_parse_exception","reason":"Illegal unquoted character ((CTRL-CHAR, code 0)): has to be escaped using 
backslash to be included in string value\n at [Source: (ByteArrayInputStream); line: 1, column: 45]"},"status":400}
```
we cannot propagate this with sinkResponseHandler.

This merge request aims to solve this issue.