### PR TITLE
fix: set metrics collector returns builder

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -240,8 +240,9 @@ func (c *ConnectorBuilder) SetLogger(logrus *logrus.Logger) *ConnectorBuilder {
 	return c
 }
 
-func (c *ConnectorBuilder) SetMetricCollectors(collectors ...prometheus.Collector) {
+func (c *ConnectorBuilder) SetMetricCollectors(collectors ...prometheus.Collector) *ConnectorBuilder {
 	c.metricCollectors = append(c.metricCollectors, collectors...)
+	return c
 }
 
 func (c *ConnectorBuilder) SetSinkResponseHandler(sinkResponseHandler dcpElasticsearch.SinkResponseHandler) *ConnectorBuilder {


### PR DESCRIPTION
SetMetricCollectors() function now returns the builder to chain builder functions.