### PR TITLE
Support skip items from batch

### DIFF
--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -377,10 +377,7 @@ func (b *Bulk) GetMetric() *Metric {
 
 func removeSkippedFromBatch(batchItems []*dcpElasticsearch.BatchItem) []*dcpElasticsearch.BatchItem {
 	batchItems = slices.DeleteFunc(batchItems, func(item *dcpElasticsearch.BatchItem) bool {
-		if item.IsSkipped {
-			return true
-		}
-		return false
+		return item.IsSkipped
 	})
 
 	return batchItems

--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -272,6 +273,7 @@ func (b *Bulk) flushMessages() {
 	if b.isDcpRebalancing {
 		return
 	}
+	b.removeSkippedFromBatch()
 	if len(b.batch) > 0 {
 		if b.sinkResponseHandler != nil {
 			b.sinkResponseHandler.OnBeforeBulk(&dcpElasticsearch.SinkResponseHandlerBulkContext{
@@ -300,6 +302,16 @@ func (b *Bulk) flushMessages() {
 		b.batchByteSize = 0
 	}
 	b.CheckAndCommit()
+}
+
+func (b *Bulk) removeSkippedFromBatch() {
+	b.batch = slices.DeleteFunc(b.batch, func(item *dcpElasticsearch.BatchItem) bool {
+		if item.IsSkipped {
+			metaPool.Put(item.Bytes)
+			return true
+		}
+		return false
+	})
 }
 
 func (b *Bulk) CheckAndCommit() {

--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -273,7 +273,6 @@ func (b *Bulk) flushMessages() {
 	if b.isDcpRebalancing {
 		return
 	}
-	b.removeSkippedFromBatch()
 	if len(b.batch) > 0 {
 		if b.sinkResponseHandler != nil {
 			b.sinkResponseHandler.OnBeforeBulk(&dcpElasticsearch.SinkResponseHandlerBulkContext{
@@ -302,16 +301,6 @@ func (b *Bulk) flushMessages() {
 		b.batchByteSize = 0
 	}
 	b.CheckAndCommit()
-}
-
-func (b *Bulk) removeSkippedFromBatch() {
-	b.batch = slices.DeleteFunc(b.batch, func(item *dcpElasticsearch.BatchItem) bool {
-		if item.IsSkipped {
-			metaPool.Put(item.Bytes)
-			return true
-		}
-		return false
-	})
 }
 
 func (b *Bulk) CheckAndCommit() {
@@ -384,6 +373,17 @@ func (b *Bulk) bulkRequest() error {
 
 func (b *Bulk) GetMetric() *Metric {
 	return b.metric
+}
+
+func removeSkippedFromBatch(batchItems []*dcpElasticsearch.BatchItem) []*dcpElasticsearch.BatchItem {
+	batchItems = slices.DeleteFunc(batchItems, func(item *dcpElasticsearch.BatchItem) bool {
+		if item.IsSkipped {
+			return true
+		}
+		return false
+	})
+
+	return batchItems
 }
 
 func hasResponseError(r *esapi.Response) (map[string]string, error) {
@@ -534,6 +534,8 @@ func getActionKey(action document.ESActionDocument) string {
 }
 
 func getBytes(batchItems []*dcpElasticsearch.BatchItem) [][]byte {
+	batchItems = removeSkippedFromBatch(batchItems)
+
 	batchBytes := make([][]byte, 0, len(batchItems))
 	for _, batchItem := range batchItems {
 		batchBytes = append(batchBytes, batchItem.Bytes)

--- a/elasticsearch/bulk/bulk.go
+++ b/elasticsearch/bulk/bulk.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -375,14 +374,6 @@ func (b *Bulk) GetMetric() *Metric {
 	return b.metric
 }
 
-func removeSkippedFromBatch(batchItems []*dcpElasticsearch.BatchItem) []*dcpElasticsearch.BatchItem {
-	batchItems = slices.DeleteFunc(batchItems, func(item *dcpElasticsearch.BatchItem) bool {
-		return item.IsSkipped
-	})
-
-	return batchItems
-}
-
 func hasResponseError(r *esapi.Response) (map[string]string, error) {
 	if r == nil {
 		return nil, fmt.Errorf("esapi response is nil")
@@ -531,19 +522,25 @@ func getActionKey(action document.ESActionDocument) string {
 }
 
 func getBytes(batchItems []*dcpElasticsearch.BatchItem) [][]byte {
-	batchItems = removeSkippedFromBatch(batchItems)
-
 	batchBytes := make([][]byte, 0, len(batchItems))
 	for _, batchItem := range batchItems {
+		if batchItem.IsSkipped {
+			continue
+		}
+
 		batchBytes = append(batchBytes, batchItem.Bytes)
 	}
 	return batchBytes
 }
 
 func getActions(batchItems []*dcpElasticsearch.BatchItem) []*document.ESActionDocument {
-	result := make([]*document.ESActionDocument, len(batchItems))
-	for i := range batchItems {
-		result[i] = batchItems[i].Action
+	result := make([]*document.ESActionDocument, 0, len(batchItems))
+	for _, batchItem := range batchItems {
+		if batchItem.IsSkipped {
+			continue
+		}
+
+		result = append(result, batchItem.Action)
 	}
 	return result
 }

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -221,6 +221,78 @@ func Test_getActions(t *testing.T) {
 	}
 }
 
+func TestBulk_removeSkippedFromBatch(t *testing.T) {
+	t.Run("drops_IsSkipped_items_keeps_order_of_rest", func(t *testing.T) {
+		keepA := &document.ESActionDocument{ID: []byte("keepA"), IndexName: testIndexName}
+		skip := &document.ESActionDocument{ID: []byte("skip"), IndexName: testIndexName}
+		keepC := &document.ESActionDocument{ID: []byte("keepC"), IndexName: testIndexName}
+
+		sut := &Bulk{}
+		sut.batch = []*elasticsearch.BatchItem{
+			{Action: keepA, IsSkipped: false},
+			{Action: skip, IsSkipped: true, Bytes: []byte("skipBytes")},
+			{Action: keepC, IsSkipped: false},
+		}
+
+		sut.removeSkippedFromBatch()
+
+		if len(sut.batch) != 2 {
+			t.Fatalf("Expected batch length to be 2 but got %d", len(sut.batch))
+		}
+		if sut.batch[0].Action != keepA {
+			t.Fatal("Expected first action to be keepA")
+		}
+		if sut.batch[1].Action != keepC {
+			t.Fatal("Expected second action to be keepC")
+		}
+	})
+
+	t.Run("empty_batch", func(t *testing.T) {
+		sut := &Bulk{}
+		sut.removeSkippedFromBatch()
+		if len(sut.batch) != 0 {
+			t.Fatalf("Expected batch length to be 0 but got %d", len(sut.batch))
+		}
+	})
+
+	t.Run("all_skipped", func(t *testing.T) {
+		sut := &Bulk{}
+		sut.batch = []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: true, Bytes: []byte("bytes1")},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true, Bytes: []byte("bytes2")},
+		}
+
+		sut.removeSkippedFromBatch()
+
+		if len(sut.batch) != 0 {
+			t.Fatalf("Expected batch length to be 0 but got %d", len(sut.batch))
+		}
+	})
+
+	t.Run("none_skipped_unchanged", func(t *testing.T) {
+		actionA := &document.ESActionDocument{ID: []byte("1")}
+		actionB := &document.ESActionDocument{ID: []byte("2")}
+
+		sut := &Bulk{}
+		sut.batch = []*elasticsearch.BatchItem{
+			{Action: actionA, IsSkipped: false},
+			{Action: actionB, IsSkipped: false},
+		}
+
+		sut.removeSkippedFromBatch()
+
+		if len(sut.batch) != 2 {
+			t.Fatalf("Expected batch length to be 2 but got %d", len(sut.batch))
+		}
+		if sut.batch[0].Action != actionA {
+			t.Fatal("Expected first action to be actionA")
+		}
+		if sut.batch[1].Action != actionB {
+			t.Fatal("Expected second action to be actionB")
+		}
+	})
+}
+
 func assertJSONEqual(t *testing.T, expected, actual string) {
 	t.Helper()
 	expectedParts := strings.Split(strings.TrimSpace(expected), "\n")

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -292,7 +292,6 @@ func Test_getBytes(t *testing.T) {
 	})
 }
 
-
 func assertJSONEqual(t *testing.T, expected, actual string) {
 	t.Helper()
 	expectedParts := strings.Split(strings.TrimSpace(expected), "\n")

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -221,74 +221,52 @@ func Test_getActions(t *testing.T) {
 	}
 }
 
-func TestBulk_removeSkippedFromBatch(t *testing.T) {
-	t.Run("drops_IsSkipped_items_keeps_order_of_rest", func(t *testing.T) {
-		keepA := &document.ESActionDocument{ID: []byte("keepA"), IndexName: testIndexName}
-		skip := &document.ESActionDocument{ID: []byte("skip"), IndexName: testIndexName}
-		keepC := &document.ESActionDocument{ID: []byte("keepC"), IndexName: testIndexName}
-
-		sut := &Bulk{}
-		sut.batch = []*elasticsearch.BatchItem{
-			{Action: keepA, IsSkipped: false},
-			{Action: skip, IsSkipped: true, Bytes: []byte("skipBytes")},
-			{Action: keepC, IsSkipped: false},
+func Test_removeSkippedFromBatch(t *testing.T) {
+	t.Run("removes_skipped_items", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: false},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true},
+			{Action: &document.ESActionDocument{ID: []byte("3")}, IsSkipped: false},
 		}
 
-		sut.removeSkippedFromBatch()
+		result := removeSkippedFromBatch(given)
 
-		if len(sut.batch) != 2 {
-			t.Fatalf("Expected batch length to be 2 but got %d", len(sut.batch))
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items but got %d", len(result))
 		}
-		if sut.batch[0].Action != keepA {
-			t.Fatal("Expected first action to be keepA")
-		}
-		if sut.batch[1].Action != keepC {
-			t.Fatal("Expected second action to be keepC")
+		if string(result[0].Action.ID) != "1" || string(result[1].Action.ID) != "3" {
+			t.Fatal("non-skipped items must be preserved in order")
 		}
 	})
+	t.Run("returns_all_when_none_skipped", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: false},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: false},
+		}
 
-	t.Run("empty_batch", func(t *testing.T) {
-		sut := &Bulk{}
-		sut.removeSkippedFromBatch()
-		if len(sut.batch) != 0 {
-			t.Fatalf("Expected batch length to be 0 but got %d", len(sut.batch))
+		result := removeSkippedFromBatch(given)
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items but got %d", len(result))
 		}
 	})
-
-	t.Run("all_skipped", func(t *testing.T) {
-		sut := &Bulk{}
-		sut.batch = []*elasticsearch.BatchItem{
-			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: true, Bytes: []byte("bytes1")},
-			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true, Bytes: []byte("bytes2")},
+	t.Run("returns_empty_when_all_skipped", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: true},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true},
 		}
 
-		sut.removeSkippedFromBatch()
+		result := removeSkippedFromBatch(given)
 
-		if len(sut.batch) != 0 {
-			t.Fatalf("Expected batch length to be 0 but got %d", len(sut.batch))
+		if len(result) != 0 {
+			t.Fatalf("expected 0 items but got %d", len(result))
 		}
 	})
+	t.Run("returns_empty_when_input_is_empty", func(t *testing.T) {
+		result := removeSkippedFromBatch([]*elasticsearch.BatchItem{})
 
-	t.Run("none_skipped_unchanged", func(t *testing.T) {
-		actionA := &document.ESActionDocument{ID: []byte("1")}
-		actionB := &document.ESActionDocument{ID: []byte("2")}
-
-		sut := &Bulk{}
-		sut.batch = []*elasticsearch.BatchItem{
-			{Action: actionA, IsSkipped: false},
-			{Action: actionB, IsSkipped: false},
-		}
-
-		sut.removeSkippedFromBatch()
-
-		if len(sut.batch) != 2 {
-			t.Fatalf("Expected batch length to be 2 but got %d", len(sut.batch))
-		}
-		if sut.batch[0].Action != actionA {
-			t.Fatal("Expected first action to be actionA")
-		}
-		if sut.batch[1].Action != actionB {
-			t.Fatal("Expected second action to be actionB")
+		if len(result) != 0 {
+			t.Fatalf("expected 0 items but got %d", len(result))
 		}
 	})
 }

--- a/elasticsearch/bulk/bulk_test.go
+++ b/elasticsearch/bulk/bulk_test.go
@@ -204,50 +204,35 @@ func Test_fillErrorDataWithBulkRequestError(t *testing.T) {
 }
 
 func Test_getActions(t *testing.T) {
-	givenBatchItems := []*elasticsearch.BatchItem{
-		{Action: &document.ESActionDocument{ID: []byte("1")}},
-		{Action: &document.ESActionDocument{ID: []byte("2")}},
-	}
+	t.Run("returns_all_when_none_skipped", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}},
+			{Action: &document.ESActionDocument{ID: []byte("2")}},
+		}
 
-	expected := []*document.ESActionDocument{
-		{ID: []byte("1")},
-		{ID: []byte("2")},
-	}
+		result := getActions(given)
 
-	result := getActions(givenBatchItems)
-
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatal("Must be equal")
-	}
-}
-
-func Test_removeSkippedFromBatch(t *testing.T) {
-	t.Run("removes_skipped_items", func(t *testing.T) {
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items but got %d", len(result))
+		}
+		if string(result[0].ID) != "1" || string(result[1].ID) != "2" {
+			t.Fatal("actions must be preserved in order")
+		}
+	})
+	t.Run("skips_skipped_items", func(t *testing.T) {
 		given := []*elasticsearch.BatchItem{
 			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: false},
 			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true},
 			{Action: &document.ESActionDocument{ID: []byte("3")}, IsSkipped: false},
 		}
 
-		result := removeSkippedFromBatch(given)
+		result := getActions(given)
 
 		if len(result) != 2 {
-			t.Fatalf("expected 2 items but got %d", len(result))
+			t.Fatalf("expected 2 actions but got %d", len(result))
 		}
-		if string(result[0].Action.ID) != "1" || string(result[1].Action.ID) != "3" {
-			t.Fatal("non-skipped items must be preserved in order")
-		}
-	})
-	t.Run("returns_all_when_none_skipped", func(t *testing.T) {
-		given := []*elasticsearch.BatchItem{
-			{Action: &document.ESActionDocument{ID: []byte("1")}, IsSkipped: false},
-			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: false},
-		}
-
-		result := removeSkippedFromBatch(given)
-
-		if len(result) != 2 {
-			t.Fatalf("expected 2 items but got %d", len(result))
+		if string(result[0].ID) != "1" || string(result[1].ID) != "3" {
+			t.Fatal("non-skipped actions must be preserved in order")
 		}
 	})
 	t.Run("returns_empty_when_all_skipped", func(t *testing.T) {
@@ -256,20 +241,57 @@ func Test_removeSkippedFromBatch(t *testing.T) {
 			{Action: &document.ESActionDocument{ID: []byte("2")}, IsSkipped: true},
 		}
 
-		result := removeSkippedFromBatch(given)
+		result := getActions(given)
 
 		if len(result) != 0 {
-			t.Fatalf("expected 0 items but got %d", len(result))
-		}
-	})
-	t.Run("returns_empty_when_input_is_empty", func(t *testing.T) {
-		result := removeSkippedFromBatch([]*elasticsearch.BatchItem{})
-
-		if len(result) != 0 {
-			t.Fatalf("expected 0 items but got %d", len(result))
+			t.Fatalf("expected 0 actions but got %d", len(result))
 		}
 	})
 }
+
+func Test_getBytes(t *testing.T) {
+	t.Run("returns_all_when_none_skipped", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, Bytes: []byte("a")},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, Bytes: []byte("b")},
+		}
+
+		result := getBytes(given)
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 byte slices but got %d", len(result))
+		}
+	})
+	t.Run("skips_skipped_items", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Action: &document.ESActionDocument{ID: []byte("1")}, Bytes: []byte("a"), IsSkipped: false},
+			{Action: &document.ESActionDocument{ID: []byte("2")}, Bytes: []byte("b"), IsSkipped: true},
+			{Action: &document.ESActionDocument{ID: []byte("3")}, Bytes: []byte("c"), IsSkipped: false},
+		}
+
+		result := getBytes(given)
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 byte slices but got %d", len(result))
+		}
+		if string(result[0]) != "a" || string(result[1]) != "c" {
+			t.Fatal("non-skipped bytes must be preserved in order")
+		}
+	})
+	t.Run("returns_empty_when_all_skipped", func(t *testing.T) {
+		given := []*elasticsearch.BatchItem{
+			{Bytes: []byte("a"), IsSkipped: true},
+			{Bytes: []byte("b"), IsSkipped: true},
+		}
+
+		result := getBytes(given)
+
+		if len(result) != 0 {
+			t.Fatalf("expected 0 byte slices but got %d", len(result))
+		}
+	})
+}
+
 
 func assertJSONEqual(t *testing.T, expected, actual string) {
 	t.Helper()

--- a/elasticsearch/model.go
+++ b/elasticsearch/model.go
@@ -5,6 +5,7 @@ import (
 )
 
 type BatchItem struct {
-	Action *document.ESActionDocument
-	Bytes  []byte
+	Action    *document.ESActionDocument
+	Bytes     []byte
+	IsSkipped bool
 }

--- a/elasticsearch/model.go
+++ b/elasticsearch/model.go
@@ -9,3 +9,7 @@ type BatchItem struct {
 	Bytes     []byte
 	IsSkipped bool
 }
+
+func (b *BatchItem) MarkSkipped() {
+	b.IsSkipped = true
+}


### PR DESCRIPTION
After 'OnBeforeBulk', items with 'IsSkipped' are removed from the batch so they are not included in the bulk request. 
Their byte buffers returned to 'metaPool'. 

Tests added.